### PR TITLE
fix: allow skipping deploy-build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
                 default: true
                 required: false
                 type: boolean
+            skip_deploy_build:
+                description: Whether to publish to D2 artifacts
+                default: false
+                required: false
+                type: boolean
         secrets:
             DHIS2_BOT_GITHUB_TOKEN:
                 required: true
@@ -43,6 +48,7 @@ jobs:
                   github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
                   apphub-token: ${{ secrets.DHIS2_BOT_APPHUB_TOKEN }}
             - uses: dhis2/deploy-build@master
+              if: ${{ inputs.skip_deploy_build == false }}
               with:
                   build-dir: build/app
                   github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This allows skipping the deploy to d2-ci from the release job, so that the job can be re-used outside DHIS2 context.