### PR TITLE
feat: expose apphub_channel in custom workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
                 default: true
                 required: false
                 type: boolean
+            apphub_channel:
+                description: The channel to use for publishing to apphub
+                default: 'stable'
+                required: false
+                type: string
             publish_github:
                 description: Whether to publish to github
                 default: true
@@ -45,6 +50,7 @@ jobs:
               with:
                   publish-apphub: ${{ inputs.publish_apphub }}
                   publish-github: ${{ inputs.publish_github }}
+                  apphub-channel: ${{ inputs.apphub_channel }}
                   github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
                   apphub-token: ${{ secrets.DHIS2_BOT_APPHUB_TOKEN }}
             - uses: dhis2/deploy-build@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
                 required: false
                 type: boolean
             apphub_channel:
-                description: The channel to use for publishing to apphub
+                description: The channel to use for publishing to apphub (stable, development or canary)
                 default: 'stable'
                 required: false
                 type: string


### PR DESCRIPTION
the custom workflow seems to always publish to stable channel - this exposes an option to choose a channel (which then the consumer can specify)