### PR TITLE
fix: pin node version

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -20,7 +20,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 20.19
                   cache: yarn
             - run: yarn install --frozen-lockfile
             - run: yarn d2-app-scripts build --standalone

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -15,7 +15,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 20.19
                   cache: yarn
             - run: yarn install --frozen-lockfile
             - run: yarn d2-app-scripts build --standalone

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,7 +21,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 20.19
                   cache: yarn
             - run: yarn install --frozen-lockfile
             - run: yarn d2-app-scripts build --standalone

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 20.19
                   cache: yarn
             - uses: cypress-io/github-action@v6
               with:

--- a/.github/workflows/legacy-e2e.yml
+++ b/.github/workflows/legacy-e2e.yml
@@ -14,7 +14,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 20.19
                   cache: yarn
             - uses: cypress-io/github-action@v6
               with:

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -10,7 +10,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 20.19
                   cache: yarn
             - run: yarn install --frozen-lockfile
             - id: commitlint

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -8,7 +8,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 20.19
                   cache: yarn
             - run: yarn install --frozen-lockfile
             - id: commitlint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 20.19
                   cache: yarn
             - run: yarn install --frozen-lockfile
             - run: yarn d2-app-scripts i18n generate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
                   token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 20.19
                   cache: yarn
             - run: yarn install --frozen-lockfile
             - run: yarn d2-app-scripts build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 20.19
                   cache: yarn
             - run: yarn install --frozen-lockfile
             - run: yarn d2-app-scripts i18n generate


### PR DESCRIPTION
There is an error that started creeping on CI related to Ethiopian calendar [RangeError: Era aa (ISO year 2014) was not matched by any era](https://github.com/dhis2/multi-calendar-dates/actions/runs/23558705116/job/68592750238#step:6:72) .. this is apparently an issue with node in [the minor upgrade from 20.19 to 20.20](https://github.com/nodejs/node/pull/60523) (upgrade to ICU, International components for unicode) - it can be fixed for now by pinning the CI node version to 20.19 specifically, rather than just 20 , but the proper fix is to update multi-calendar to the latest standard Temporal